### PR TITLE
restart SSE loop when getting a timeout and state exists

### DIFF
--- a/finegrain/requirements.lock
+++ b/finegrain/requirements.lock
@@ -20,9 +20,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.28.1
-    # via finegrain-python
+    # via finegrain
 httpx-sse==0.4.0
-    # via finegrain-python
+    # via finegrain
 idna==3.10
     # via anyio
     # via httpx


### PR DESCRIPTION
This typically means there was a silent disconnection of the SSE loop. This happens in practice. There should be a better way to detect it but let's try to be more reliable for now.