### PR TITLE
discord: mitigate output files size limit

### DIFF
--- a/examples/discord/requirements.lock
+++ b/examples/discord/requirements.lock
@@ -23,7 +23,7 @@ attrs==25.1.0
 certifi==2025.1.31
     # via httpcore
     # via httpx
-discord-py==2.4.0
+discord-py==2.5.2
     # via finegrain-discord
 environs==14.1.0
     # via finegrain-discord


### PR DESCRIPTION
Brute-force approach (webp encoding of both input/output images, which should be enough most of the time).