### PR TITLE
discord: add login, logout and info commands

### DIFF
--- a/examples/discord/.env.example
+++ b/examples/discord/.env.example
@@ -11,4 +11,6 @@ DISCORD_GUILD_ID=0
 FG_API_URL="https://api.finegrain.ai/editor"
 # FG_CA_BUNDLE="/home/.../.local/share/mkcert/rootCA.pem"
 
+USERS_DB="users.db"
+
 LOGLEVEL="INFO"

--- a/examples/discord/.env.example
+++ b/examples/discord/.env.example
@@ -9,7 +9,6 @@ DISCORD_GUILD_ID=0
 
 # See https://api.finegrain.ai/doc/
 FG_API_URL="https://api.finegrain.ai/editor"
-FG_API_KEY="FGAPI-XXXXXX-..."
 # FG_CA_BUNDLE="/home/.../.local/share/mkcert/rootCA.pem"
 
 LOGLEVEL="INFO"

--- a/examples/discord/.env.example
+++ b/examples/discord/.env.example
@@ -9,8 +9,7 @@ DISCORD_GUILD_ID=0
 
 # See https://api.finegrain.ai/doc/
 FG_API_URL="https://api.finegrain.ai/editor"
-FG_API_USER="your-email@example.com"
-FG_API_PASSWORD="REPLACEME"
+FG_API_KEY="FGAPI-XXXXXX-..."
 # FG_CA_BUNDLE="/home/.../.local/share/mkcert/rootCA.pem"
 
 LOGLEVEL="INFO"


### PR DESCRIPTION
This gets rid of the single, pre-defined user with credentials in `.env` file. Instead, users can now log in via API key.